### PR TITLE
Is this a bug? array is a Float32Array

### DIFF
--- a/stft.js
+++ b/stft.js
@@ -64,7 +64,7 @@ class STFT{
         for(let i = 0; i < this.hopSize; i++){
             this.prevProcessed[i] += overlapWindow[i +this.hopSize];
         }
-        this.prevRaw = array;
+        this.prevRaw = buffer;
         return result;
     }
 


### PR DESCRIPTION
The original code would be setting this.prevRaw = Float32Array, which doesn't make sense because it cannot be sliced.

From the other page it seems this should be set to buffer instead.